### PR TITLE
added include directives for dna_bwt.hpp in bwt_lcp_thresholds.cpp an…

### DIFF
--- a/test/src/bwt_lcp.cpp
+++ b/test/src/bwt_lcp.cpp
@@ -32,6 +32,7 @@
 
 #include <lcp.hpp>
 #include <unistd.h>
+#include <dna_bwt.hpp>
 #include <dna_bwt_n.hpp>
 
 #include <malloc_count.h>

--- a/test/src/bwt_lcp_thresholds.cpp
+++ b/test/src/bwt_lcp_thresholds.cpp
@@ -32,6 +32,7 @@
 
 #include <lcp.hpp>
 #include <unistd.h>
+#include <dna_bwt.hpp>
 #include <dna_bwt_n.hpp>
 
 #include <malloc_count.h>

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -149,7 +149,7 @@ endif()
 ## Add bwt2lcp
 FetchContent_Declare(
   bwt2lcp
-  GIT_REPOSITORY https://github.com/nicolaprezza/bwt2lcp
+  GIT_REPOSITORY https://github.com/dove-begleiter/bwt2lcp
 )
 
 FetchContent_GetProperties(bwt2lcp)


### PR DESCRIPTION
…d bwt_lcp.cpp so that project will build. switched thirdparty/CMakeLists.txt to use dove-begleiter/bwt2lcp instead of nicolaprezza/bwt2lcp